### PR TITLE
Add support for rendering `nonisolated` and `@MainActor` type definitions in Swift.

### DIFF
--- a/staticcode/StaticCode.pkl
+++ b/staticcode/StaticCode.pkl
@@ -22,6 +22,7 @@ import "Kotlin.pkl"
 import "Swift.pkl"
 
 typealias Language = "Swift" | "Kotlin"
+typealias Isolation = "nonisolated" | "@MainActor"
 
 /// A value renderer that outputs Swift code.
 class Renderer extends ValueRenderer {
@@ -29,17 +30,21 @@ class Renderer extends ValueRenderer {
   language: Language
   /// The package that the rendered file belongs to.
   ///
-  /// Only used for the Kotlin language
+  /// Only used for the Kotlin language.
   packageName = ""
   /// The top-level object's name.
   objectName = "Configuration"
+  /// An explicit isolation to be used in the rendered code.
+  ///
+  /// Only used for the Swift language.
+  isolation: Isolation?
 
   converters: Mapping<Class | String, (unknown) -> Any>
   extension = if (language == "Swift") "swift" else "kt"
 
   function renderDocument(value: Any) =
     if (value is Module)
-      let (reflectedModule = reflectObject(objectName, value, false))
+      let (reflectedModule = reflectObject(objectName, value, false, isolation))
       let (
         header =
           if (language == "Kotlin" && !packageName.isEmpty) "package \(packageName)\n\n" else ""
@@ -53,7 +58,7 @@ class Renderer extends ValueRenderer {
   function reflectType(property: reflect.Property, value: Any, isDefinition: Boolean): ReflectedType =
     if (value is Typed)
       let (nullable = property.type is reflect.NullableType)
-        reflectObject(property.name, value, nullable)
+        reflectObject(property.name, value, nullable, isolation)
     else if (property.type is reflect.DeclaredType || property.type is reflect.NullableType)
       let (unwrappedTypeName = unwrapType(property.type).referent.reflectee.simpleName)
         if (value == null && !valueTypes.contains(unwrappedTypeName))
@@ -66,7 +71,12 @@ class Renderer extends ValueRenderer {
     else
       throw("\(property.name) has unsupported type: \(value.getClass())")
 
-  local function reflectObject(_name: String, _value: Typed, _nullable: Boolean): ReflectedType =
+  local function reflectObject(
+    _name: String,
+    _value: Typed,
+    _nullable: Boolean,
+    _isolation: Isolation?,
+  ): ReflectedType =
     let (reflectedClass = reflect.Class(_value.getClass()))
     let (
       _properties =
@@ -88,6 +98,7 @@ class Renderer extends ValueRenderer {
           name = _name
           typeName = _typeName
           nullable = _nullable
+          isolation = _isolation
           properties = _properties
         }
       else
@@ -116,11 +127,13 @@ class Renderer extends ValueRenderer {
         else
           reflectedClass.name
     )
+    let (_isolation = isolation)
       if (language == "Swift")
         new Swift.ReflectedObject {
           name = property.name
           typeName = _typeName
           nullable = true
+          isolation = _isolation
           properties = _properties
         }
       else

--- a/staticcode/Swift.pkl
+++ b/staticcode/Swift.pkl
@@ -30,6 +30,8 @@ class ReflectedObject extends StaticCode.ReflectedType {
   typeName: String
   /// Whether or not this object is allowed to be null.
   nullable: Boolean
+  /// The object's isolation.
+  isolation: StaticCode.Isolation?
   /// All of the object's properties.
   properties: List<StaticCode.ReflectedType>
 
@@ -39,7 +41,7 @@ class ReflectedObject extends StaticCode.ReflectedType {
   /// Renders the object as a top level enum containing static properties and and custom type definitions.
   function render(indentLevel: Int): String =
     """
-    \(indent(indentLevel))enum \(name.capitalize()) {
+    \(indent(indentLevel))\(typeAnnotation)enum \(name.capitalize()) {
     \(properties
       .map((property) ->
         if (property is ReflectedObject)
@@ -73,7 +75,7 @@ class ReflectedObject extends StaticCode.ReflectedType {
   /// Renders the object's definition without any values.
   function renderDefinition(indentLevel: Int): String =
     """
-    \(indent(indentLevel))struct \(renderedType) {
+    \(indent(indentLevel))\(typeAnnotation)struct \(renderedType) {
     \(properties
       .map((property) ->
         if (property is ReflectedObject)
@@ -98,6 +100,12 @@ class ReflectedObject extends StaticCode.ReflectedType {
       )
       .toMap((property) -> property.typeName, (property) -> property)
       .values // Remove duplicates based on typeName.
+
+  hidden fixed typeAnnotation: String =
+    if (isolation != null)
+      isolation + " "
+    else
+      ""
 }
 
 /// An object's property without an accompanying value.

--- a/staticcode/tests/StaticCodeTests.pkl
+++ b/staticcode/tests/StaticCodeTests.pkl
@@ -27,12 +27,25 @@ examples {
   ["Standard Types: Swift"] {
     StandardTypes.output.text
   }
+  ["Standard Types: Swift nonisolated"] {
+    (StandardTypes) { output { renderer = makeSwift6Renderer("StandardTypes", "nonisolated") } }
+      .output
+      .text
+  }
+  ["Standard Types: Swift @MainActor"] {
+    (StandardTypes) { output { renderer = makeSwift6Renderer("StandardTypes", "@MainActor") } }
+      .output
+      .text
+  }
   ["Standard Types: Kotlin"] {
     (StandardTypes) { output { renderer = makeKotlinRenderer("StandardTypes") } }.output.text
   }
 
   ["Basic: Swift"] {
     Basic.output.text
+  }
+  ["Basic: Swift nonisolated"] {
+    (Basic) { output { renderer = makeSwift6Renderer("User", "nonisolated") } }.output.text
   }
   ["Basic: Kotlin"] {
     (Basic) { output { renderer = makeKotlinRenderer("User") } }.output.text
@@ -41,12 +54,24 @@ examples {
   ["Multiple Instances: Swift"] {
     MultipleInstances.output.text
   }
+  ["Multiple Instances: Swift nonisolated"] {
+    (MultipleInstances) { output { renderer = makeSwift6Renderer("Equipment", "nonisolated") } }
+      .output
+      .text
+  }
   ["Multiple Instances: Kotlin"] {
     (MultipleInstances) { output { renderer = makeKotlinRenderer("Equipment") } }.output.text
   }
 
   ["Nullable Properties: Swift"] {
     NullableProperties.output.text
+  }
+  ["Nullable Properties: Swift nonisolated"] {
+    (NullableProperties) {
+      output { renderer = makeSwift6Renderer("NullableProperties", "nonisolated") }
+    }
+      .output
+      .text
   }
   ["Nullable Properties: Kotlin"] {
     (NullableProperties) { output { renderer = makeKotlinRenderer("NullableProperties") } }
@@ -57,6 +82,9 @@ examples {
   ["Modules: Swift"] {
     Modules.output.text
   }
+  ["Modules: Swift nonisolated"] {
+    (Modules) { output { renderer = makeSwift6Renderer("People", "nonisolated") } }.output.text
+  }
   ["Modules: Kotlin"] {
     (Modules) { output { renderer = makeKotlinRenderer("People") } }.output.text
   }
@@ -66,4 +94,11 @@ local function makeKotlinRenderer(_objectName: String) = new StaticCode.Renderer
   language = "Kotlin"
   packageName = "my.package"
   objectName = _objectName
+}
+
+local function makeSwift6Renderer(_objectName: String, _isolation: StaticCode.Isolation) = new StaticCode
+  .Renderer {
+  language = "Swift"
+  objectName = _objectName
+  isolation = _isolation
 }

--- a/staticcode/tests/StaticCodeTests.pkl-expected.pcf
+++ b/staticcode/tests/StaticCodeTests.pkl-expected.pcf
@@ -30,6 +30,68 @@ examples {
     }
     """
   }
+  ["Standard Types: Swift nonisolated"] {
+    """
+    nonisolated enum StandardTypes {
+        static let someString: String = "Hello, World!"
+        static let someOptionalString: String? = nil
+        static let someObject: SomeClass = SomeClass(
+            someString: "bob",
+            someInteger: 0,
+            anEmptyStringList: [],
+            anIntList: [1, 2, 3],
+            aStringList: ["A", "B", "C"],
+            someNestedObject: SomeOtherClass(
+                someBoolean: false,
+                someDecimal: 0.5
+            )
+        )
+        nonisolated struct SomeClass {
+            let someString: String
+            let someInteger: Int
+            let anEmptyStringList: Array<String>
+            let anIntList: Array<Int>
+            let aStringList: Array<String>
+            let someNestedObject: SomeOtherClass
+        }
+        nonisolated struct SomeOtherClass {
+            let someBoolean: Bool
+            let someDecimal: Double
+        }
+    }
+    """
+  }
+  ["Standard Types: Swift @MainActor"] {
+    """
+    @MainActor enum StandardTypes {
+        static let someString: String = "Hello, World!"
+        static let someOptionalString: String? = nil
+        static let someObject: SomeClass = SomeClass(
+            someString: "bob",
+            someInteger: 0,
+            anEmptyStringList: [],
+            anIntList: [1, 2, 3],
+            aStringList: ["A", "B", "C"],
+            someNestedObject: SomeOtherClass(
+                someBoolean: false,
+                someDecimal: 0.5
+            )
+        )
+        @MainActor struct SomeClass {
+            let someString: String
+            let someInteger: Int
+            let anEmptyStringList: Array<String>
+            let anIntList: Array<Int>
+            let aStringList: Array<String>
+            let someNestedObject: SomeOtherClass
+        }
+        @MainActor struct SomeOtherClass {
+            let someBoolean: Bool
+            let someDecimal: Double
+        }
+    }
+    """
+  }
   ["Standard Types: Kotlin"] {
     """
     package my.package
@@ -72,6 +134,15 @@ examples {
     }
     """
   }
+  ["Basic: Swift nonisolated"] {
+    """
+    nonisolated enum User {
+        static let name: String = "Alice"
+        static let friends: Array<String> = ["Bob", "Charlie"]
+    
+    }
+    """
+  }
   ["Basic: Kotlin"] {
     """
     package my.package
@@ -108,6 +179,37 @@ examples {
             let name: String
         }
         struct Cover {
+            let name: String
+            let device: Device
+        }
+    }
+    """
+  }
+  ["Multiple Instances: Swift nonisolated"] {
+    """
+    nonisolated enum Equipment {
+        static let phone: Device = Device(
+            name: "iPhone"
+        )
+        static let tablet: Device = Device(
+            name: "iPad"
+        )
+        static let laptop: Device = Device(
+            name: "MacBook"
+        )
+        static let desktop: Device = Device(
+            name: "iMac"
+        )
+        static let cover: Cover = Cover(
+            name: "Magic Keyboard",
+            device: Device(
+                name: "iPad"
+            )
+        )
+        nonisolated struct Device {
+            let name: String
+        }
+        nonisolated struct Cover {
             let name: String
             let device: Device
         }
@@ -178,6 +280,37 @@ examples {
     }
     """
   }
+  ["Nullable Properties: Swift nonisolated"] {
+    """
+    nonisolated enum NullableProperties {
+        static let nullableString: String? = nil
+        static let nullableObject: OuterClass? = OuterClass(
+            required: InnerClass(
+                value: true
+            ),
+            requiredWithNull: NullableInnerClass(
+                value: nil
+            ),
+            nullObject: nil
+        )
+        static let nullObject: UnusedClass? = nil
+        nonisolated struct OuterClass {
+            let required: InnerClass
+            let requiredWithNull: NullableInnerClass
+            let nullObject: InnerClass?
+        }
+        nonisolated struct InnerClass {
+            let value: Bool
+        }
+        nonisolated struct NullableInnerClass {
+            let value: Bool?
+        }
+        nonisolated struct UnusedClass {
+            let value: String
+        }
+    }
+    """
+  }
   ["Nullable Properties: Kotlin"] {
     """
     package my.package
@@ -220,6 +353,21 @@ examples {
         )
         static let bob: Person? = nil
         struct Person {
+            let name: String
+            let age: Int
+        }
+    }
+    """
+  }
+  ["Modules: Swift nonisolated"] {
+    """
+    nonisolated enum People {
+        static let alice: Person = Person(
+            name: "Alice",
+            age: 25
+        )
+        static let bob: Person? = nil
+        nonisolated struct Person {
             let name: String
             let age: Int
         }


### PR DESCRIPTION
I've added support for both
- `nonisolated` – useful when using Swift 6's default actor isolation.
- `@MainActor` – potentially useful when not using default actor isolation but not something we specifically need.